### PR TITLE
Update FlatFileMap interface naming and introduce TypedFFMap

### DIFF
--- a/ffmap/file_map.go
+++ b/ffmap/file_map.go
@@ -14,24 +14,24 @@ func OpenCSV(filename string) (*KeyValueCSV, error) {
 }
 
 // OpenReadOnlyCSV will read a CSV map file, providing a read only view of the data.
-func OpenReadOnlyCSV(filename string) (FlatFileMap, error) {
+func OpenReadOnlyCSV(filename string) (FFMap, error) {
 	return OpenCSV(filename)
 }
 
-type FlatFileMap interface {
+type FFMap interface {
 	// Size reports how many entries are stored in the map.
 	Size() int
 	// Get will set the value for the given key.  The returned bool indicates if the value was found and matches the
 	// type, check the error for possible parsing or type errors.
 	Get(key string, value interface{}) (bool, error)
-	// ContainsKey will return true if the map has an associated value with the provided key
+	// ContainsKey will return true if the map has an associated value with the provided key.
 	ContainsKey(key string) bool
 	// KeySet will return all the keys stored within the map.
 	KeySet() []string
 }
 
-type WritableFlatFileMap interface {
-	FlatFileMap
+type MutableFFMap interface {
+	FFMap
 	// Set will set the provided value into the map, when retrieved the same type must be used.  If a value already
 	// exists, it will be replaced with the new value.
 	Set(key string, value interface{}) error
@@ -40,4 +40,54 @@ type WritableFlatFileMap interface {
 	// Commit will update the disk representation to match the in-memory state.  If this is not invoked the disk will
 	// never be updated.  This must not be called concurrently, and may be slow as the file format is optimized.
 	Commit() error
+}
+
+// TypedFFMap provides a similar API to the interface MutableFFMap, however it only functions on a single value type.
+type TypedFFMap[T any] struct {
+	ffm MutableFFMap
+}
+
+// NewTypedFFMap provides a TypedFFMap which will operate with only the specific generic value type provided.
+// If the underline map contains values of other types, an error will be returned when the value is attempted to be retrieved.
+func NewTypedFFMap[T any](ffm MutableFFMap) *TypedFFMap[T] {
+	return &TypedFFMap[T]{ffm}
+}
+
+// Size reports how many entries are stored in the map.
+func (tfm *TypedFFMap[T]) Size() int {
+	return tfm.ffm.Size()
+}
+
+// Get will set the value for the given key.  The returned bool indicates if the value was found, if false the returned
+// value is nil or invalid for the type.
+func (tfm *TypedFFMap[T]) Get(key string) (T, bool) {
+	var val T
+	ok, err := tfm.ffm.Get(key, &val)
+	return val, ok && err == nil
+}
+
+// ContainsKey will return true if the map has an associated value with the provided key.
+func (tfm *TypedFFMap[T]) ContainsKey(key string) bool {
+	return tfm.ffm.ContainsKey(key)
+}
+
+// KeySet will return all the keys stored within the map.
+func (tfm *TypedFFMap[T]) KeySet() []string {
+	return tfm.ffm.KeySet()
+}
+
+// Set will set the provided value into the map.  If a value already exists, it will be replaced with the new value.
+func (tfm *TypedFFMap[T]) Set(key string, value T) error {
+	return tfm.ffm.Set(key, value)
+}
+
+// Delete will remove the key from the map (if present).
+func (tfm *TypedFFMap[T]) Delete(key string) {
+	tfm.ffm.Delete(key)
+}
+
+// Commit will update the disk representation to match the in-memory state.  If this is not invoked the disk will
+// never be updated.  This must not be called concurrently, and may be slow as the file format is optimized.
+func (tfm *TypedFFMap[T]) Commit() error {
+	return tfm.ffm.Commit()
 }

--- a/ffmap/file_map_test.go
+++ b/ffmap/file_map_test.go
@@ -1,0 +1,138 @@
+package ffmap
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type memoryFFMap struct {
+	data map[string]interface{}
+}
+
+func newMemoryFFMap() *memoryFFMap {
+	return &memoryFFMap{
+		data: make(map[string]interface{}),
+	}
+}
+
+func (m *memoryFFMap) Size() int {
+	return len(m.data)
+}
+
+func (m *memoryFFMap) Get(key string, value interface{}) (bool, error) {
+	storedValue, exists := m.data[key]
+	if !exists {
+		return false, nil
+	}
+
+	valType := reflect.TypeOf(value)
+	if reflect.TypeOf(storedValue) != valType.Elem() {
+		return false, fmt.Errorf("type mismatch: expected %v, got %v", valType.Elem(), reflect.TypeOf(storedValue))
+	}
+
+	reflect.ValueOf(value).Elem().Set(reflect.ValueOf(storedValue))
+	return true, nil
+}
+
+func (m *memoryFFMap) ContainsKey(key string) bool {
+	_, exists := m.data[key]
+	return exists
+}
+
+func (m *memoryFFMap) KeySet() []string {
+	keys := make([]string, 0, len(m.data))
+	for k := range m.data {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+func (m *memoryFFMap) Set(key string, value interface{}) error {
+	m.data[key] = value
+	return nil
+}
+
+func (m *memoryFFMap) Delete(key string) {
+	delete(m.data, key)
+}
+
+func (m *memoryFFMap) Commit() error {
+	return nil
+}
+
+func TestTypedFFMap(t *testing.T) {
+	t.Run("Size", func(t *testing.T) {
+		t.Parallel()
+		tfm := NewTypedFFMap[string](newMemoryFFMap())
+
+		assert.Equal(t, 0, tfm.Size())
+
+		err := tfm.Set("key", "value")
+		require.NoError(t, err)
+
+		assert.Equal(t, 1, tfm.Size())
+	})
+	t.Run("GetMissing", func(t *testing.T) {
+		t.Parallel()
+		tfm := NewTypedFFMap[string](newMemoryFFMap())
+
+		_, ok := tfm.Get("foo")
+		assert.False(t, ok)
+	})
+	t.Run("SetAndGet", func(t *testing.T) {
+		t.Parallel()
+		tfm := NewTypedFFMap[string](newMemoryFFMap())
+
+		key := "key"
+		value := "value"
+		err := tfm.Set(key, value)
+		require.NoError(t, err)
+
+		result, ok := tfm.Get(key)
+		assert.True(t, ok)
+		assert.NoError(t, err)
+		assert.Equal(t, value, result)
+	})
+	t.Run("ContainsKey", func(t *testing.T) {
+		t.Parallel()
+		tfm := NewTypedFFMap[string](newMemoryFFMap())
+		key := "key"
+
+		assert.False(t, tfm.ContainsKey(key))
+
+		err := tfm.Set(key, "value")
+		require.NoError(t, err)
+
+		assert.True(t, tfm.ContainsKey(key))
+	})
+	t.Run("KeySet", func(t *testing.T) {
+		t.Parallel()
+		tfm := NewTypedFFMap[string](newMemoryFFMap())
+		key := "key"
+
+		assert.Len(t, tfm.KeySet(), 0)
+
+		err := tfm.Set(key, "value")
+		require.NoError(t, err)
+		keyset := tfm.KeySet()
+
+		require.Len(t, keyset, 1)
+		assert.Equal(t, key, keyset[0])
+	})
+	t.Run("Delete", func(t *testing.T) {
+		t.Parallel()
+		tfm := NewTypedFFMap[string](newMemoryFFMap())
+
+		key := "key"
+		err := tfm.Set(key, "value")
+		require.NoError(t, err)
+		tfm.Delete(key)
+
+		assert.False(t, tfm.ContainsKey(key))
+		assert.Equal(t, 0, tfm.Size())
+	})
+}


### PR DESCRIPTION
This change renames `FlatFileMap` to the more concise `FFMap` and `WritableFlatFileMap` to the more concise `MutableFFMap`.

In addition a new type is introduced, `TypedFFMap`, which with generics allows the value type to be defined, and makes for a simpler Get interface.