### PR TITLE
Expand linting configuration and improve CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,28 +7,47 @@ on:
     branches: [ main ]
 
 jobs:
+  lint-and-tidy:
+    name: Verify Linting
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
 
-  build:
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.23"
+
+      - name: Set up golangci-lint
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin latest
+
+      - name: Run lint check
+        run: make lint
+
+      - name: Run tidy check
+        run: |
+          go mod tidy
+          # Fail if go.mod or go.sum changed
+          git diff --exit-code go.mod go.sum
+
+  test:
+    name: Verify Unit Tests
     runs-on: ubuntu-latest
     strategy:
       matrix:
         go:
+        - '1.23'
         - '1.22'
         - '1.21'
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: ${{ matrix.go }}
+      - name: Set up Go ${{ matrix.go }}
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go }}
 
-    - name: Get dependencies
-      run:
-        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin latest
+      - name: Run unit tests
+        run: make test
 
-    - name: Test
-      run: make test
-
-    - name: Lint
-      run: make lint

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,13 @@
-.PHONY: default test lint
+export GO111MODULE = on
+
+.PHONY: default test test-cover lint
 
 test:
 	go test -race -cover ./...
 
+test-cover:
+	go test -race -coverprofile=test.out ./... && go tool cover --html=test.out
+
 lint:
-	golangci-lint run
+	golangci-lint run --timeout=600s --enable=asasalint,asciicheck,bidichk,containedctx,contextcheck,exportloopref,decorder,durationcheck,errorlint,exptostd,fatcontext,forbidigo,gocheckcompilerdirectives,gochecksumtype,goconst,gofmt,goimports,gosmopolitan,grouper,iface,importas,mirror,misspell,nilerr,nilnil,perfsprint,prealloc,reassign,recvcheck,sloglint,testifylint,unconvert,wastedassign,whitespace
+

--- a/ffmap/csv_map_test.go
+++ b/ffmap/csv_map_test.go
@@ -626,7 +626,7 @@ func TestSetError(t *testing.T) {
 			tmpFile, m := makeTestMap(t)
 			defer os.Remove(tmpFile)
 
-			assert.Error(t, m.Set("key", tc.setValue))
+			require.Error(t, m.Set(tc.name, tc.setValue))
 			assert.Equal(t, 0, m.Size())
 		})
 	}
@@ -725,7 +725,7 @@ func TestGetOverflowError(t *testing.T) {
 			require.NoError(t, m.Set(key, tc.setValue))
 
 			found, err := m.Get(key, tc.getValue)
-			assert.Error(t, err)
+			require.Error(t, err)
 			assert.False(t, found)
 		})
 	}
@@ -761,7 +761,7 @@ func TestGetInvalidType(t *testing.T) {
 
 			valPtr := reflect.New(reflect.TypeOf(mismatchValue))
 			found, err := m.Get(key, valPtr.Interface())
-			assert.Errorf(t, err, "error expected looking up %s with type %s", key, mismatchKey)
+			require.Errorf(t, err, "error expected looking up %s with type %s", key, mismatchKey)
 			assert.False(t, found)
 		}
 	}
@@ -964,7 +964,7 @@ func TestEncodingSize(t *testing.T) {
 			valueHolder, found := m.data[key1]
 			assert.True(t, found)
 			value := valueHolder.value
-			assert.Equalf(t, tc.expectedStrSize, len(value), "unexpected encoded value: %s", value)
+			assert.Lenf(t, value, tc.expectedStrSize, "unexpected encoded value size: %s", value)
 
 			require.NoError(t, m.Commit())
 			verifyFileSize(t, tmpFile, tc.expectedFileSizeOne)
@@ -1031,7 +1031,7 @@ func TestDelete(t *testing.T) {
 	tmpFile, m := makeTestMap(t)
 	defer os.Remove(tmpFile)
 
-	key := "testKey"
+	key := "keyDelete"
 	value := "testValue"
 	require.NoError(t, m.Set(key, value))
 
@@ -1045,7 +1045,7 @@ func TestDeleteAll(t *testing.T) {
 	tmpFile, m := makeTestMap(t)
 	defer os.Remove(tmpFile)
 
-	key := "key"
+	key := "keyDeleteAll"
 	require.NoError(t, m.Set(key, "value"))
 	require.NoError(t, m.Set("foo"+key, "value"))
 
@@ -1062,7 +1062,7 @@ func verifyEmpty(t *testing.T, m *KeyValueCSV, oldKey string) {
 	require.NoError(t, err)
 	assert.False(t, found)
 	assert.Equal(t, 0, m.Size())
-	assert.Len(t, m.KeySet(), 0)
+	assert.Empty(t, m.KeySet())
 }
 
 func FuzzLoadRecords(f *testing.F) {

--- a/ffmap/file_map_test.go
+++ b/ffmap/file_map_test.go
@@ -75,7 +75,7 @@ func TestTypedFFMap(t *testing.T) {
 
 		assert.Equal(t, 0, tfm.Size())
 
-		err := tfm.Set("key", "value")
+		err := tfm.Set("keySize", "value")
 		require.NoError(t, err)
 
 		assert.Equal(t, 1, tfm.Size())
@@ -91,20 +91,20 @@ func TestTypedFFMap(t *testing.T) {
 		t.Parallel()
 		tfm := NewTypedFFMap[string](newMemoryFFMap())
 
-		key := "key"
+		key := "keySetAndGet"
 		value := "value"
 		err := tfm.Set(key, value)
 		require.NoError(t, err)
 
 		result, ok := tfm.Get(key)
 		assert.True(t, ok)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, value, result)
 	})
 	t.Run("ContainsKey", func(t *testing.T) {
 		t.Parallel()
 		tfm := NewTypedFFMap[string](newMemoryFFMap())
-		key := "key"
+		key := "ContainsKey"
 
 		assert.False(t, tfm.ContainsKey(key))
 
@@ -118,7 +118,7 @@ func TestTypedFFMap(t *testing.T) {
 		tfm := NewTypedFFMap[string](newMemoryFFMap())
 		key := "key"
 
-		assert.Len(t, tfm.KeySet(), 0)
+		assert.Empty(t, tfm.KeySet())
 
 		err := tfm.Set(key, "value")
 		require.NoError(t, err)
@@ -131,7 +131,7 @@ func TestTypedFFMap(t *testing.T) {
 		t.Parallel()
 		tfm := NewTypedFFMap[string](newMemoryFFMap())
 
-		key := "key"
+		key := "keyDelete"
 		err := tfm.Set(key, "value")
 		require.NoError(t, err)
 		tfm.Delete(key)
@@ -143,7 +143,7 @@ func TestTypedFFMap(t *testing.T) {
 		t.Parallel()
 		tfm := NewTypedFFMap[string](newMemoryFFMap())
 
-		key := "key"
+		key := "keyDeleteAll"
 		require.NoError(t, tfm.Set(key, "value"))
 		require.NoError(t, tfm.Set("foo"+key, "value"))
 		tfm.DeleteAll()


### PR DESCRIPTION
Changes included:
* `make lint` updated to enable additional linters to help maintain the project style.
* PR validation updated to include go 1.23 (and run lint and tests concurrently)
* PR tests now also verify that `go mod tidy` has already been performed
* Consistency changes with slices in `csv_map` also gave some minor performance gains.