### PR TITLE
fix: Multiple struct optimization when `omitempty` is defined on the struct

### DIFF
--- a/ffmap/lib.go
+++ b/ffmap/lib.go
@@ -1,0 +1,26 @@
+package ffmap
+
+func mapKeys[K comparable, V any](m map[K]V) []K {
+	result := make([]K, 0, len(m))
+	for k := range m {
+		result = append(result, k)
+	}
+	return result
+}
+
+func sliceUniqueUnion[T comparable](slice [][]T) []T {
+	switch len(slice) {
+	case 0:
+		return nil
+	case 1:
+		return slice[0]
+	}
+
+	uniqMap := make(map[T]bool)
+	for _, s := range slice {
+		for _, v := range s {
+			uniqMap[v] = true
+		}
+	}
+	return mapKeys(uniqMap)
+}

--- a/ffmap/lib_test.go
+++ b/ffmap/lib_test.go
@@ -1,0 +1,94 @@
+package ffmap
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMapKeys(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		input  map[string]int
+		expect []string
+	}{
+		{
+			name:   "basic",
+			input:  map[string]int{"a": 1, "b": 2, "c": 3},
+			expect: []string{"a", "b", "c"},
+		},
+		{
+			name:   "empty_map",
+			input:  map[string]int{},
+			expect: []string{},
+		},
+		{
+			name:   "nil",
+			input:  nil,
+			expect: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mapKeys(tt.input)
+
+			assert.Equal(t, tt.expect, got)
+		})
+	}
+}
+
+func TestSliceUniqueUnion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input [][]int
+		want  []int
+	}{
+		{
+			name:  "unique_values",
+			input: [][]int{{1, 2}, {3, 4}},
+			want:  []int{1, 2, 3, 4},
+		},
+		{
+			name:  "middle_overlapping_values",
+			input: [][]int{{1, 2}, {2, 3}, {3, 4}},
+			want:  []int{1, 2, 3, 4},
+		},
+		{
+			name:  "single_slice",
+			input: [][]int{{1, 2, 3}},
+			want:  []int{1, 2, 3},
+		},
+		{
+			name:  "empty_slice",
+			input: [][]int{},
+			want:  nil,
+		},
+		{
+			name:  "nil",
+			input: nil,
+			want:  nil,
+		},
+		{
+			name:  "nested_empty_slices",
+			input: [][]int{{}, {}},
+			want:  []int{},
+		},
+		{
+			name:  "duplicate_values_in_slice",
+			input: [][]int{{1, 1, 2}, {2, 3, 3}},
+			want:  []int{1, 2, 3},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sliceUniqueUnion(tt.input)
+			assert.ElementsMatch(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
When multiple matching structs are stored in the map, prior to this change only the encoded fields of the first struct were inspected. Because of our use of json encoding, that means that if the struct is defined with `omitempty`, any fields in the first instance not filled in the first instance wont be encoded for all remaining instances.

This change does an extra Unmarshal of all instances to ensure that all filled in fields are included in our map. Although there is a slight performance impact from this, it is an important check for us to do.