### PR TITLE
feat: Minimize encoded size by removing default values

### DIFF
--- a/ffmap/csv_map.go
+++ b/ffmap/csv_map.go
@@ -154,7 +154,7 @@ func encodeValue(value interface{}) (*dataItem, error) {
 	var strVal string
 	switch v := value.(type) {
 	case nil:
-		return nil, errors.New("can not encode nil value")
+		return nil, errors.New("cannot encode nil value")
 	case string:
 		dataType = dataString
 		strVal = v
@@ -179,14 +179,18 @@ func encodeValue(value interface{}) (*dataItem, error) {
 		strVal = fmt.Sprintf("%v", v)
 	default:
 		val := reflect.ValueOf(value)
-		if val.Kind() == reflect.Ptr { // If it's a pointer, get the value it points to
-			val = val.Elem()
+		if val.Kind() == reflect.Ptr {
+			if val.IsNil() {
+				return nil, errors.New("cannot encode nil pointer")
+			}
+			val = val.Elem() // get the value the pointer references
 		}
-		if val.Kind() == reflect.Slice || val.Kind() == reflect.Array {
+		switch val.Kind() {
+		case reflect.Slice, reflect.Array:
 			dataType = dataArraySlice
-		} else if val.Kind() == reflect.Map {
+		case reflect.Map:
 			dataType = dataMap
-		} else {
+		default:
 			dataType = dataStructJson
 			// this id is only used for comparison but must remain consistent for a given file version
 			// We have to consider the field names so that don't mix structs which have had field updates between versions
@@ -200,13 +204,173 @@ func encodeValue(value interface{}) (*dataItem, error) {
 				structId += "-" + strconv.FormatUint(uint64(crc32.Checksum(combinedFieldName.Bytes(), crc32q)), 36)
 			}
 		}
-		bytes, err := json.Marshal(v)
+		bytes, err := json.Marshal(stripZeroFields(val))
 		if err != nil {
 			return nil, err
 		}
 		strVal = string(bytes)
 	}
 	return &dataItem{dataType: dataType, structId: structId, value: strVal}, nil
+}
+
+// stripZeroFields removes default / empty / zero-value fields from a struct while preserving non-nil pointers
+// and correctly serializing custom json.Marshaler types. It also preserves []byte so that json.Marshal
+// will encode them as base64, and preserves fixed‐size byte arrays so that they remain JSON arrays.
+//
+// This allows us to reduce our stored json to only what is necessary to accurately recreate the struct state on Get.
+func stripZeroFields(v reflect.Value) interface{} {
+	if !v.IsValid() {
+		return nil
+	}
+
+	// Special-case: for byte slices and arrays, return as-is so that json.Marshal encodes them as base64
+	if (v.Kind() == reflect.Slice || v.Kind() == reflect.Array) && v.Type().Elem().Kind() == reflect.Uint8 {
+		return v.Interface()
+	}
+
+	// If the type implements json.Marshaler, use that.
+	if v.CanInterface() {
+		if marshaler, ok := v.Interface().(json.Marshaler); ok {
+			if jsonBytes, err := marshaler.MarshalJSON(); err == nil {
+				var unmarshaled interface{}
+				if err := json.Unmarshal(jsonBytes, &unmarshaled); err == nil {
+					return unmarshaled
+				}
+			}
+		}
+	}
+
+	// Handle pointer: if non-nil, and if its element is considered empty (for non-collection types)
+	// then return the pointer (preserving an explicit pointer to an empty or default value),
+	// otherwise process its element.
+	if v.Kind() == reflect.Ptr {
+		if v.IsNil() {
+			return nil
+		}
+		elem := v.Elem()
+		// For slices and maps we want to process the element normally,
+		// so only shortcut if the pointer points to a non-collection empty value.
+		if elem.Kind() != reflect.Slice && elem.Kind() != reflect.Map && isZeroValue(elem) {
+			return v.Interface()
+		}
+		return stripZeroFields(elem)
+	}
+
+	switch v.Kind() {
+	case reflect.Struct:
+		out := make(map[string]interface{})
+		typ := v.Type()
+		for i := 0; i < v.NumField(); i++ {
+			fieldType := typ.Field(i)
+			if fieldType.PkgPath != "" {
+				continue // Skip unexported fields
+			}
+			fieldVal := v.Field(i)
+			jsonKey := fieldType.Name
+			if tag, ok := fieldType.Tag.Lookup("json"); ok {
+				tagParts := strings.Split(tag, ",")
+				if tagParts[0] == "-" {
+					continue // omit fields with json:"-"
+				} else if tagParts[0] != "" {
+					jsonKey = tagParts[0]
+				}
+			}
+			// For slices and maps, preserve them if non-nil (even if empty).
+			if fieldVal.Kind() == reflect.Slice || fieldVal.Kind() == reflect.Map {
+				if fieldVal.IsNil() {
+					continue
+				}
+			} else if isZeroValue(fieldVal) {
+				continue
+			}
+			out[jsonKey] = stripZeroFields(fieldVal)
+		}
+		// Even if all fields were omitted, we want to preserve an empty struct
+		// so that a pointer to an empty struct remains non-nil.
+		return out
+	case reflect.Slice:
+		if v.Len() == 0 {
+			if v.IsNil() {
+				return nil
+			}
+			return []interface{}{}
+		}
+		out := make([]interface{}, v.Len())
+		for i := 0; i < v.Len(); i++ {
+			out[i] = stripZeroFields(v.Index(i))
+		}
+		return out
+	case reflect.Array:
+		// Arrays cannot be nil so we always process them.
+		if v.Len() == 0 {
+			return v.Interface()
+		}
+		out := make([]interface{}, v.Len())
+		for i := 0; i < v.Len(); i++ {
+			out[i] = stripZeroFields(v.Index(i))
+		}
+		return out
+	case reflect.Map:
+		if v.Len() == 0 {
+			if v.IsNil() {
+				return nil
+			}
+			return map[string]interface{}{}
+		}
+		out := make(map[string]interface{})
+		for _, key := range v.MapKeys() {
+			// use fmt.Sprint to ensure JSON-compatible keys
+			out[fmt.Sprint(key.Interface())] = stripZeroFields(v.MapIndex(key))
+		}
+		return out
+	default:
+		if isZeroValue(v) {
+			return nil
+		}
+		return v.Interface()
+	}
+}
+
+// isEmptyValue determines whether a reflect.Value is its type's zero value.
+// For slices and maps emptiness is defined by nil rather than Len()==0,
+// so that non-nil empty slices/maps (which the user explicitly provided) are preserved.
+func isZeroValue(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Bool:
+		return !v.Bool()
+	case reflect.String:
+		return v.Len() == 0
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return v.Int() == 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return v.Uint() == 0
+	case reflect.Float32, reflect.Float64:
+		return v.Float() == 0
+	case reflect.Slice, reflect.Map:
+		return v.IsNil() // only consider nil to match prior default pointer behavior
+	case reflect.Array:
+		return v.Len() == 0
+	case reflect.Ptr, reflect.Interface:
+		return v.IsNil()
+	case reflect.Struct:
+		// If the struct implements json.Marshaler, check its output.
+		if v.CanInterface() {
+			if marshaler, ok := v.Interface().(json.Marshaler); ok {
+				if jsonBytes, err := marshaler.MarshalJSON(); err == nil {
+					s := string(jsonBytes)
+					return s == `""` || s == `{}`
+				}
+			}
+		}
+		for i := 0; i < v.NumField(); i++ {
+			if !isZeroValue(v.Field(i)) {
+				return false
+			}
+		}
+		return true
+	default:
+		return false
+	}
 }
 
 func decodeValue(dataType int, encodedValue string, value interface{}) error {

--- a/ffmap/csv_map_test.go
+++ b/ffmap/csv_map_test.go
@@ -1,6 +1,7 @@
 package ffmap
 
 import (
+	"encoding/json"
 	"fmt"
 	"math"
 	"os"
@@ -37,6 +38,99 @@ func makeTestMap(t *testing.T) (string, *KeyValueCSV) {
 	}
 	return tmpfile.Name(), m
 }
+
+type TestNamedStruct struct {
+	Value     string
+	ID        int
+	Float     float64
+	Bool      bool
+	Map       map[string]TestNamedStruct
+	MapIntKey map[int]string
+	Time      time.Time
+	Bytes     []byte
+	IntSlice  []int
+}
+
+type TestPointerStruct struct {
+	T *time.Time
+	I *int
+	S *string
+	B *bool
+	F *float64
+}
+
+type TestCustomJsonStruct struct {
+	Value    string  `json:"v"`
+	EmptyStr string  `json:"emptyStr,omitempty"`
+	EmptyInt int     `json:"emptyInt,omitempty"`
+	NilPtr   *string `json:"nilPtr,omitempty"`
+	ZValue   string  `json:"zv"`
+}
+
+type TestNestedStruct struct {
+	Inner TestNamedStruct
+	Ptr   *TestNamedStruct
+}
+
+type TestStructWithSlice struct {
+	Values []TestNamedStruct
+}
+
+type TestStructWithEmbeddedAnonymous struct {
+	Embedded struct {
+		Name string
+		ID   int
+	}
+	Extra string
+}
+
+type TestStructWithPointerToAnonymous struct {
+	Ptr *struct {
+		Name string
+		ID   int
+	}
+}
+
+type TestStructWithPointerToEmpty struct {
+	Ptr *struct{}
+}
+
+type TestCustomMarshaler struct {
+	Value   string
+	Encoded json.RawMessage
+}
+
+type TestStructWithEmbeddedCustomMarshaler struct {
+	Embedded TestCustomMarshaler
+	Extra    string
+}
+
+type TestStructWithMultiPointer struct {
+	PPP ***int
+}
+
+type TestStructWithDeepNesting struct {
+	Level1 struct {
+		Level2 struct {
+			Level3 struct {
+				Value string
+				Num   int
+			}
+		}
+	}
+}
+
+type TestStructWithDeeplyNestedMap struct {
+	Data map[string]interface{}
+}
+
+var (
+	defaultStr = ""
+	defaultI   = 0
+	defaultT   = time.Time{}
+	defaultB   = false
+	defaultF   = 0.0
+)
 
 func TestOpenAndCommit(t *testing.T) {
 	t.Run("OpenEmpty", func(t *testing.T) {
@@ -282,26 +376,9 @@ func TestSize(t *testing.T) {
 	}
 }
 
-type TestNamedStruct struct {
-	Value string
-	ID    int
-	Float float64
-	Bool  bool
-	Map   map[string]TestNamedStruct
-	Time  time.Time
-	Bytes []byte
-}
-
-type TestCustomJsonStruct struct {
-	Value    string  `json:"v"`
-	EmptyStr string  `json:"emptyStr,omitempty"`
-	EmptyInt int     `json:"emptyInt,omitempty"`
-	NilPtr   *string `json:"nilPtr,omitempty"`
-	ZValue   string  `json:"zv"`
-}
-
 func TestEncodeValueType(t *testing.T) {
 	t.Parallel()
+
 	testCases := []struct {
 		name             string
 		value            interface{}
@@ -402,6 +479,15 @@ func TestEncodeValueType(t *testing.T) {
 			expectedDataType: dataStructJson,
 		},
 		{
+			name: "PointerStruct",
+			value: TestPointerStruct{
+				S: &defaultStr,
+				I: &defaultI,
+				T: &defaultT,
+			},
+			expectedDataType: dataStructJson,
+		},
+		{
 			name: "CustomJsonStruct",
 			value: TestCustomJsonStruct{
 				Value: "foo",
@@ -475,6 +561,46 @@ func TestEncodeValueType(t *testing.T) {
 			name:             "StructPointer",
 			value:            &TestNamedStruct{Value: "foo", ID: 123},
 			expectedDataType: dataStructJson,
+		},
+		{
+			name:             "Float32Slice",
+			value:            []float32{1.1, 2.2, 3.3},
+			expectedDataType: dataArraySlice,
+		},
+		{
+			name:             "Float64Slice",
+			value:            []float64{1.1, 2.2, 3.3},
+			expectedDataType: dataArraySlice,
+		},
+		{
+			name:             "UintSlice",
+			value:            []uint{1, 2, 3, 4},
+			expectedDataType: dataArraySlice,
+		},
+		{
+			name:             "NestedIntSlice",
+			value:            [][]int{{1, 2}, {3, 4}},
+			expectedDataType: dataArraySlice,
+		},
+		{
+			name:             "NestedStringSlice",
+			value:            [][]string{{"a", "b"}, {"c", "d"}},
+			expectedDataType: dataArraySlice,
+		},
+		{
+			name:             "EmptySlice",
+			value:            []int{},
+			expectedDataType: dataArraySlice,
+		},
+		{
+			name:             "EmptyArray",
+			value:            [0]int{},
+			expectedDataType: dataArraySlice,
+		},
+		{
+			name:             "PointerSlice",
+			value:            []*int{new(int), new(int)},
+			expectedDataType: dataArraySlice,
 		},
 	}
 
@@ -583,11 +709,33 @@ func TestSetAndGet(t *testing.T) {
 		{
 			name: "NamedStruct",
 			setValue: TestNamedStruct{
-				Value: "foo",
-				ID:    123,
-				Map:   map[string]TestNamedStruct{"bar": {Value: "bar", ID: 987, Bool: true}},
+				Value:     "foo",
+				ID:        123,
+				Map:       map[string]TestNamedStruct{"bar": {Value: "bar", ID: 987, Bool: true}},
+				MapIntKey: map[int]string{1: "one", 2: "two"},
+				Time:      time.Date(2025, 2, 16, 10, 20, 40, 20, time.UTC),
+				IntSlice:  []int{0, 0, 0, 0},
 			},
 			getValue: new(TestNamedStruct),
+		},
+		{
+			name:     "NamedStructEmpty",
+			setValue: TestNamedStruct{},
+			getValue: new(TestNamedStruct),
+		},
+		{
+			name:     "NamedStructPointer",
+			setValue: &TestNamedStruct{},
+			getValue: new(*TestNamedStruct),
+		},
+		{
+			name: "PointerStruct",
+			setValue: TestPointerStruct{
+				S: &defaultStr,
+				I: &defaultI,
+				T: &defaultT,
+			},
+			getValue: new(TestPointerStruct),
 		},
 		{
 			name: "CustomJsonStructEmpty",
@@ -669,6 +817,591 @@ func TestSetAndGet(t *testing.T) {
 			setValue: &TestNamedStruct{Value: "foo", ID: 123},
 			getValue: new(*TestNamedStruct),
 		},
+		{
+			name:     "NestedMap",
+			setValue: map[string]map[string]int{"outer": {"inner": 42}},
+			getValue: new(map[string]map[string]int),
+		},
+		{
+			name:     "MixedTypeSlice",
+			setValue: []interface{}{"two", 3.0},
+			getValue: new([]interface{}),
+		},
+		{
+			name:     "PointerSlice",
+			setValue: []*int{new(int), new(int)},
+			getValue: new([]*int),
+		},
+		{
+			name:     "UintSlice",
+			setValue: []uint{10, 20, 30},
+			getValue: new([]uint),
+		},
+		{
+			name:     "Uint8Slice",
+			setValue: []uint8{1, 2, 3, 4},
+			getValue: new([]uint8),
+		},
+		{
+			name:     "Uint16Slice",
+			setValue: []uint16{100, 200, 300},
+			getValue: new([]uint16),
+		},
+		{
+			name:     "Uint32Slice",
+			setValue: []uint32{1000, 2000, 3000},
+			getValue: new([]uint32),
+		},
+		{
+			name:     "Uint64Slice",
+			setValue: []uint64{10000, 20000, 30000},
+			getValue: new([]uint64),
+		},
+		{
+			name:     "Float32Slice",
+			setValue: []float32{3.14, 6.28},
+			getValue: new([]float32),
+		},
+		{
+			name:     "Float64Slice",
+			setValue: []float64{3.1415, 2.718},
+			getValue: new([]float64),
+		},
+		{
+			name:     "BoolSlice",
+			setValue: []bool{true, false, true},
+			getValue: new([]bool),
+		},
+		{
+			name:     "UintArray",
+			setValue: [4]uint{10, 20, 30, 40},
+			getValue: new([4]uint),
+		},
+		{
+			name:     "Uint8Array",
+			setValue: [4]uint8{1, 2, 3, 4},
+			getValue: new([4]uint8),
+		},
+		{
+			name:     "Uint16Array",
+			setValue: [4]uint16{100, 200, 300, 400},
+			getValue: new([4]uint16),
+		},
+		{
+			name:     "Uint32Array",
+			setValue: [4]uint32{1000, 2000, 3000, 4000},
+			getValue: new([4]uint32),
+		},
+		{
+			name:     "Uint64Array",
+			setValue: [4]uint64{10000, 20000, 30000, 40000},
+			getValue: new([4]uint64),
+		},
+		{
+			name:     "Float32Array",
+			setValue: [4]float32{3.14, 6.28, 9.42, 12.56},
+			getValue: new([4]float32),
+		},
+		{
+			name:     "Float64Array",
+			setValue: [4]float64{3.1415, 2.718, 1.618, 0.577},
+			getValue: new([4]float64),
+		},
+		{
+			name:     "BoolArray",
+			setValue: [4]bool{true, false, true, false},
+			getValue: new([4]bool),
+		},
+		{
+			name: "NestedStruct",
+			setValue: TestNestedStruct{
+				Inner: TestNamedStruct{
+					Value: "nested",
+					ID:    999,
+				},
+				Ptr: &TestNamedStruct{
+					Value: "pointer",
+					ID:    888,
+				},
+			},
+			getValue: new(TestNestedStruct),
+		},
+		{
+			name: "StructWithSlice",
+			setValue: TestStructWithSlice{
+				Values: []TestNamedStruct{
+					{Value: "first", ID: 1},
+					{Value: "second", ID: 2},
+				},
+			},
+			getValue: new(TestStructWithSlice),
+		},
+		{
+			name: "PointerStructExpanded",
+			setValue: TestPointerStruct{
+				S: &defaultStr,
+				I: &defaultI,
+				T: &defaultT,
+				B: &defaultB,
+				F: &defaultF,
+			},
+			getValue: new(TestPointerStruct),
+		},
+		{
+			name:     "StructSliceAnonymous",
+			setValue: []struct{ Name string }{{Name: "Alice"}, {Name: "Bob"}},
+			getValue: new([]struct{ Name string }),
+		},
+		{
+			name:     "PointerStructSlice",
+			setValue: []*TestPointerStruct{{S: &defaultStr, I: &defaultI}, {T: &defaultT, F: &defaultF}},
+			getValue: new([]*TestPointerStruct),
+		},
+		{
+			name:     "EmptyStruct",
+			setValue: struct{}{},
+			getValue: new(struct{}),
+		},
+		{
+			name: "StructWithMixedFields",
+			setValue: struct {
+				Str  string
+				Ptr  *string
+				Bool bool
+				Num  int
+			}{Str: "test", Ptr: &defaultStr, Bool: true, Num: 42},
+			getValue: new(struct {
+				Str  string
+				Ptr  *string
+				Bool bool
+				Num  int
+			}),
+		},
+		{
+			name: "StructWithEmbeddedStruct",
+			setValue: struct {
+				Embedded TestNamedStruct
+				Extra    string
+			}{Embedded: TestNamedStruct{Value: "embed", ID: 999}, Extra: "extra"},
+			getValue: new(struct {
+				Embedded TestNamedStruct
+				Extra    string
+			}),
+		},
+		{
+			name: "PointerToEmptyStruct",
+			setValue: &struct {
+				Name string
+			}{},
+			getValue: new(*struct {
+				Name string
+			}),
+		},
+		{
+			name:     "RuneSlice",
+			setValue: []rune{'a', 'b', 'c'},
+			getValue: new([]rune),
+		},
+		{
+			name:     "ByteSliceWithZeros",
+			setValue: []byte{0, 1, 2, 3, 0},
+			getValue: new([]byte),
+		},
+		{
+			name:     "EmptyByteSlice",
+			setValue: []byte{},
+			getValue: new([]byte),
+		},
+		{
+			name:     "NilByteSlice",
+			setValue: ([]byte)(nil),
+			getValue: new([]byte),
+		},
+		{
+			name:     "StructPointerSlice",
+			setValue: []*TestNamedStruct{{Value: "first", ID: 1}, nil, {Value: "second", ID: 2}},
+			getValue: new([]*TestNamedStruct),
+		},
+		{
+			name: "StructWithEmbeddedAnonymousStruct",
+			setValue: TestStructWithEmbeddedAnonymous{
+				Embedded: struct {
+					Name string
+					ID   int
+				}{Name: "embedded", ID: 777},
+				Extra: "extra",
+			},
+			getValue: new(TestStructWithEmbeddedAnonymous),
+		},
+		{
+			name: "StructWithPointerToAnonymousStruct",
+			setValue: TestStructWithPointerToAnonymous{
+				Ptr: &struct {
+					Name string
+					ID   int
+				}{Name: "ptrAnon", ID: 888},
+			},
+			getValue: new(TestStructWithPointerToAnonymous),
+		},
+		{
+			name: "StructWithPointerToEmptyStruct",
+			setValue: TestStructWithPointerToEmpty{
+				Ptr: &struct{}{},
+			},
+			getValue: new(TestStructWithPointerToEmpty),
+		},
+		{
+			name: "MapWithEmptyValues",
+			setValue: map[string]interface{}{
+				"emptyStr":   "",
+				"emptyFloat": 0.0,
+				"emptyBool":  false,
+			},
+			getValue: new(map[string]interface{}),
+		},
+		{
+			name: "NestedPointerMap",
+			setValue: map[string]*TestNamedStruct{
+				"key1": {Value: "nested1", ID: 111},
+				"key2": nil,
+			},
+			getValue: new(map[string]*TestNamedStruct),
+		},
+		{
+			name: "StructWithInterfaceField",
+			setValue: struct {
+				Value interface{}
+			}{Value: "interfaceString"},
+			getValue: new(struct {
+				Value interface{}
+			}),
+		},
+		{
+			name: "StructWithEmbeddedAnonymousPointer",
+			setValue: struct {
+				Ptr *struct {
+					Name string
+					ID   int
+				}
+			}{Ptr: &struct {
+				Name string
+				ID   int
+			}{Name: "anonymous", ID: 789}},
+			getValue: new(struct {
+				Ptr *struct {
+					Name string
+					ID   int
+				}
+			}),
+		},
+		{
+			name: "DeeplyNestedStruct",
+			setValue: struct {
+				Level1 struct {
+					Level2 struct {
+						Level3 struct {
+							Value string
+							Num   int
+						}
+					}
+				}
+			}{
+				Level1: struct {
+					Level2 struct {
+						Level3 struct {
+							Value string
+							Num   int
+						}
+					}
+				}{
+					Level2: struct {
+						Level3 struct {
+							Value string
+							Num   int
+						}
+					}{
+						Level3: struct {
+							Value string
+							Num   int
+						}{Value: "deep", Num: 100},
+					},
+				},
+			},
+			getValue: new(struct {
+				Level1 struct {
+					Level2 struct {
+						Level3 struct {
+							Value string
+							Num   int
+						}
+					}
+				}
+			}),
+		},
+		{
+			name: "LargeIntSlice",
+			setValue: []int{
+				1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
+			},
+			getValue: new([]int),
+		},
+		{
+			name: "MapWithMixedTypes",
+			setValue: map[string]interface{}{
+				"string": "foo",
+				"float":  42.0,
+				"bool":   true,
+			},
+			getValue: new(map[string]interface{}),
+		},
+		{
+			name:     "CustomMarshalerStruct",
+			setValue: TestCustomMarshaler{Value: "test", Encoded: json.RawMessage(`"custom"`)},
+			getValue: new(TestCustomMarshaler),
+		},
+		{
+			name: "StructWithEmbeddedCustomMarshaler",
+			setValue: TestStructWithEmbeddedCustomMarshaler{
+				Embedded: TestCustomMarshaler{Value: "inner", Encoded: json.RawMessage(`"encoded"`)},
+				Extra:    "extra",
+			},
+			getValue: new(TestStructWithEmbeddedCustomMarshaler),
+		},
+		{
+			name: "StructWithMultiPointer",
+			setValue: TestStructWithMultiPointer{
+				PPP: func() ***int {
+					p := &defaultI
+					pp := &p
+					ppp := &pp
+					return ppp
+				}(),
+			},
+			getValue: new(TestStructWithMultiPointer),
+		},
+		{
+			name: "StructWithDeepNesting",
+			setValue: TestStructWithDeepNesting{
+				Level1: struct {
+					Level2 struct {
+						Level3 struct {
+							Value string
+							Num   int
+						}
+					}
+				}{
+					Level2: struct {
+						Level3 struct {
+							Value string
+							Num   int
+						}
+					}{
+						Level3: struct {
+							Value string
+							Num   int
+						}{Value: "deep", Num: 100},
+					},
+				},
+			},
+			getValue: new(TestStructWithDeepNesting),
+		},
+		{
+			name: "StructWithDeeplyNestedMap",
+			setValue: TestStructWithDeeplyNestedMap{
+				Data: map[string]interface{}{
+					"level1": map[string]interface{}{
+						"level2": map[string]interface{}{
+							"level3": map[string]interface{}{"value": "deep"},
+						},
+					},
+				},
+			},
+			getValue: new(TestStructWithDeeplyNestedMap),
+		},
+		{
+			name:     "LargeByteSlice",
+			setValue: make([]byte, 1024),
+			getValue: new([]byte),
+		},
+		{
+			name:     "MixedByteArrayAndSlice",
+			setValue: struct{ Data [4]byte }{Data: [4]byte{1, 2, 3, 4}},
+			getValue: new(struct{ Data [4]byte }),
+		},
+		{
+			name: "StructWithEmptyMap",
+			setValue: struct {
+				EmptyMap map[string]int
+			}{EmptyMap: map[string]int{}},
+			getValue: new(struct {
+				EmptyMap map[string]int
+			}),
+		},
+		{
+			name: "StructWithNilMap",
+			setValue: struct {
+				NilMap map[string]int
+			}{NilMap: nil},
+			getValue: new(struct {
+				NilMap map[string]int
+			}),
+		},
+		{
+			name: "StructWithEmptySlice",
+			setValue: struct {
+				EmptySlice []string
+			}{EmptySlice: []string{}},
+			getValue: new(struct {
+				EmptySlice []string
+			}),
+		},
+		{
+			name: "StructWithNilSlice",
+			setValue: struct {
+				NilSlice []string
+			}{NilSlice: nil},
+			getValue: new(struct {
+				NilSlice []string
+			}),
+		},
+		{
+			name: "StructWithPointerToEmptyStruct",
+			setValue: struct {
+				Ptr *struct{}
+			}{Ptr: &struct{}{}},
+			getValue: new(struct {
+				Ptr *struct{}
+			}),
+		},
+		{
+			name: "SliceOfStructsWithDefaultValues",
+			setValue: []TestNamedStruct{
+				{Value: "", ID: 0},
+				{Value: "filled", ID: 123},
+			},
+			getValue: new([]TestNamedStruct),
+		},
+		{
+			name: "StructWithInterfaceNil",
+			setValue: struct {
+				Field interface{}
+			}{Field: nil},
+			getValue: new(struct{ Field interface{} }),
+		},
+		{
+			name: "StructWithPointerToSlice",
+			setValue: struct {
+				PtrSlice *[]int
+			}{PtrSlice: &[]int{1, 2, 3}},
+			getValue: new(struct{ PtrSlice *[]int }),
+		},
+		{
+			name: "EmptyStructPointerSlice",
+			setValue: []*struct {
+				Name string
+			}{},
+			getValue: new([]*struct {
+				Name string
+			}),
+		},
+		{
+			name: "NilStructPointerSlice",
+			setValue: []*struct {
+				Name string
+			}(nil),
+			getValue: new([]*struct {
+				Name string
+			}),
+		},
+		{
+			name: "EmptyMapWithNonEmptyValues",
+			setValue: map[string]interface{}{
+				"emptyMap":  map[string]interface{}{},
+				"filledMap": map[string]interface{}{"a": 1.0},
+			},
+			getValue: new(map[string]interface{}),
+		},
+		{
+			name:     "SliceWithNilValues",
+			setValue: []interface{}{nil, "non-nil", nil},
+			getValue: new([]interface{}),
+		},
+		{
+			name: "StructWithDoublePointer",
+			setValue: struct {
+				Ptr **int
+			}{
+				Ptr: func() **int {
+					p := &defaultI
+					pp := &p
+					return pp
+				}(),
+			},
+			getValue: new(struct {
+				Ptr **int
+			}),
+		},
+		{
+			name: "StructWithTriplePointerLevels",
+			setValue: struct {
+				PP ***int
+			}{
+				PP: func() ***int {
+					p := &defaultI
+					pp := &p
+					ppp := &pp
+					return ppp
+				}(),
+			},
+			getValue: new(struct {
+				PP ***int
+			}),
+		},
+		{
+			name: "StructWithNestedPointerSlice",
+			setValue: struct {
+				PtrSlice *[]*int
+			}{
+				PtrSlice: &[]*int{new(int), nil},
+			},
+			getValue: new(struct {
+				PtrSlice *[]*int
+			}),
+		},
+		{
+			name: "MixedTypeMapWithNilValues",
+			setValue: map[string]interface{}{
+				"string": "hello",
+				"float":  3.14,
+				"bool":   true,
+				"slice":  []interface{}{"a", "b"},
+				"map":    map[string]interface{}{"a": 1.0, "b": 2.0},
+				"nil":    nil,
+			},
+			getValue: new(map[string]interface{}),
+		},
+		{
+			name: "NestedMixedMap",
+			setValue: map[string]interface{}{
+				"outer": map[string]interface{}{
+					"innerString": "value",
+					"innerMap":    map[string]interface{}{"key": 123.0},
+					"innerNil":    nil,
+				},
+			},
+			getValue: new(map[string]interface{}),
+		},
+		{
+			name: "StructWithRawMessage",
+			setValue: struct {
+				Raw json.RawMessage
+			}{
+				Raw: json.RawMessage(`{"key":"value"}`),
+			},
+			getValue: new(struct {
+				Raw json.RawMessage
+			}),
+		},
 	}
 
 	for _, tc := range testCases {
@@ -698,6 +1431,17 @@ func TestSetError(t *testing.T) {
 		{
 			name:     "NilValue",
 			setValue: nil,
+		},
+		{
+			name: "StructWithFunc",
+			setValue: struct {
+				FuncField func() int
+				Value     int
+			}{FuncField: func() int { return 42 }, Value: 100},
+		},
+		{
+			name:     "NilPointerToEmptySlice",
+			setValue: (*[]int)(nil),
 		},
 	}
 
@@ -976,24 +1720,45 @@ func TestEncodingSize(t *testing.T) {
 			expectedFileSizeTwo: 113,
 		},
 		{
+			name: "CustomStructEmptyField",
+			value: struct {
+				Name     string
+				EmptyStr string
+			}{Name: "Test"},
+			expectedStrSize:     15,
+			expectedFileSizeOne: 62,
+			expectedFileSizeTwo: 149,
+		},
+		{
 			name: "NamedStruct",
 			value: TestNamedStruct{
 				Value: "foo",
 				ID:    123,
 				Map:   map[string]TestNamedStruct{"bar": {Value: "bar", ID: 987, Bool: true}},
 			},
-			expectedStrSize:     205,
-			expectedFileSizeOne: 275,
-			expectedFileSizeTwo: 484,
+			expectedStrSize:     135,
+			expectedFileSizeOne: 193,
+			expectedFileSizeTwo: 362,
+		},
+		{
+			name: "PointerStruct",
+			value: TestPointerStruct{
+				S: &defaultStr,
+				I: &defaultI,
+				T: &defaultT,
+			},
+			expectedStrSize:     41,
+			expectedFileSizeOne: 85,
+			expectedFileSizeTwo: 167,
 		},
 		{
 			name: "CustomJsonStructEmpty",
 			value: TestCustomJsonStruct{
 				Value: "foo",
 			},
-			expectedStrSize:     19,
-			expectedFileSizeOne: 69,
-			expectedFileSizeTwo: 148,
+			expectedStrSize:     11,
+			expectedFileSizeOne: 57,
+			expectedFileSizeTwo: 135,
 		},
 		{
 			name:                "Map",
@@ -1036,9 +1801,9 @@ func TestEncodingSize(t *testing.T) {
 				{Value: "foo", ID: 123},
 				{Value: "bar", ID: 456},
 			},
-			expectedStrSize:     205,
-			expectedFileSizeOne: 273,
-			expectedFileSizeTwo: 540,
+			expectedStrSize:     111,
+			expectedFileSizeOne: 163,
+			expectedFileSizeTwo: 320,
 		},
 	}
 


### PR DESCRIPTION
This change is a further reduction in the encoded flat file map size.

This is done by removing any fields which would be initialized to their default value. We are attempting to be very careful that loading the value will still match the state as exactly as possible. This includes cases like having pointers to empty maps, or empty slices, which will be reconstructed with the same state.

Tests were added to cover this as there are a lot of corner conditions to consider, including pointers to default vlaues (which we want to maintain), or slices of default values, and the fact that we need to accept a wide range of structs from outside our package. The tests added here were confirmed to behave the same as the current `main` / released logic.

An alternative prototype was to encode the struct, decode into `map[string]interface{}`, prune, then re-encode. However we ran into more type issues, and maintaining slices of default values was challenging. This implementation is also more efficent, though admittedly with significant complexity.