### PR TITLE
fix: Ensure struct fields are zero if absent in file

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Set up golangci-lint
         run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin latest
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v1.64.8/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.64.8
 
       - name: Run lint check
         run: make lint

--- a/ffmap/csv_map_test.go
+++ b/ffmap/csv_map_test.go
@@ -2117,6 +2117,29 @@ func TestGetOverflowError(t *testing.T) {
 	}
 }
 
+func TestGetWithZeroFieldsSet(t *testing.T) {
+	t.Parallel()
+	tmpFile, m := makeTestMap(t)
+	defer os.Remove(tmpFile)
+
+	zeroStruct := TestNamedStruct{}
+	err := m.Set("zero", zeroStruct)
+	require.NoError(t, err)
+
+	valueStruct := &TestNamedStruct{ // pre-filled with values that should be cleared
+		Value: "value",
+		ID:    1,
+		Float: 1.0,
+		Bool:  true,
+		Time:  time.Now(),
+		Bytes: []byte("foo"),
+	}
+	_, err = m.Get("zero", valueStruct)
+	require.NoError(t, err)
+
+	assert.Equal(t, zeroStruct, *valueStruct)
+}
+
 func TestGetInvalidType(t *testing.T) {
 	t.Parallel()
 	tmpFile, m := makeTestMap(t)


### PR DESCRIPTION
Prior to this change if a struct field was added after the file was written, or removed for optimization, and the `Get` call was provided a struct with the fields already set, those fields would not be cleared out.

This fixes #18 by adding an extra reflect call to zero out for the type.