### PR TITLE
Add isZeroValue table tests

### DIFF
--- a/ffmap/csv_map_test.go
+++ b/ffmap/csv_map_test.go
@@ -2700,3 +2700,50 @@ func FuzzDecodeValue(f *testing.F) {
 		})
 	})
 }
+func TestIsZeroValue(t *testing.T) {
+	t.Parallel()
+
+	type sampleStruct struct{ A int }
+	var (
+		intPtrNil  *int
+		zero       = 0
+		intPtrZero = &zero
+		one        = 1
+		intPtrOne  = &one
+	)
+
+	tests := []struct {
+		name   string
+		val    interface{}
+		expect bool
+	}{
+		{name: "bool_true", val: true, expect: false},
+		{name: "bool_false", val: false, expect: true},
+		{name: "string_empty", val: "", expect: true},
+		{name: "string_nonempty", val: "foo", expect: false},
+		{name: "int_zero", val: 0, expect: true},
+		{name: "int_nonzero", val: 5, expect: false},
+		{name: "float_zero", val: 0.0, expect: true},
+		{name: "float_nonzero", val: 1.1, expect: false},
+		{name: "nil_slice", val: []int(nil), expect: true},
+		{name: "empty_slice", val: []int{}, expect: false},
+		{name: "slice_nonempty", val: []int{1}, expect: false},
+		{name: "nil_map", val: map[string]int(nil), expect: true},
+		{name: "empty_map", val: map[string]int{}, expect: false},
+		{name: "map_nonempty", val: map[string]int{"a": 1}, expect: false},
+		{name: "nil_ptr", val: intPtrNil, expect: true},
+		{name: "ptr_zero", val: intPtrZero, expect: false},
+		{name: "ptr_nonzero", val: intPtrOne, expect: false},
+		{name: "array_zero_len", val: [0]int{}, expect: true},
+		{name: "array_nonzero_len", val: [1]int{0}, expect: false},
+		{name: "struct_zero", val: sampleStruct{}, expect: true},
+		{name: "struct_nonzero", val: sampleStruct{A: 1}, expect: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isZeroValue(reflect.ValueOf(tt.val))
+			assert.Equal(t, tt.expect, got)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add new `TestIsZeroValue` table-driven test covering primitives, collections, pointers, arrays and structs

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684278fd120083298fc50b8b106f9273