### PR TITLE
ci: Update workflow layout and permissions to match other repos

### DIFF
--- a/.github/workflows/tests-main.yml
+++ b/.github/workflows/tests-main.yml
@@ -1,0 +1,13 @@
+name: Tests - Main Push
+
+on:
+  push:
+    branches: [ main ]
+
+permissions:
+  contents: read
+
+jobs:
+  call-reusable:
+    uses: ./.github/workflows/tests-workflow.yml
+

--- a/.github/workflows/tests-pr.yml
+++ b/.github/workflows/tests-pr.yml
@@ -1,0 +1,12 @@
+name: Tests - Pull Request
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  call-reusable:
+    uses: ./.github/workflows/tests-workflow.yml
+

--- a/.github/workflows/tests-workflow.yml
+++ b/.github/workflows/tests-workflow.yml
@@ -1,10 +1,10 @@
-name: Test
+name: Tests
 
 on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+  workflow_call:
+
+permissions:
+  contents: read
 
 jobs:
   lint-and-tidy:


### PR DESCRIPTION
Should be basically the same, but splits PR and main merge workflows and sets permissions to `read`